### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,16 +1,16 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new] 
-
+  before_action :authenticate_user!, only: [:new]
   def index
+    @items = Item.order(created_at: :desc)
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   def new
     @item = Item.new
   end
-
-  # def show
-  #   @user = User.find(params[:id])
-  # end
 
   def create
     @item = current_user.items.build(item_params)
@@ -20,6 +20,8 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
-  # has_one :purchase
+  has_one :purchase
   has_one_attached :image
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :category

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,5 @@
+class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :shipping_info
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   validates :birthdate, presence: true
 
   has_many :items
-  # has_many :purchases
+  has_many :purchases
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,26 +127,23 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%=number_to_currency(item.price, unit: "円") %><br><%= item.delivery_fee_burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +152,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,10 +172,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
+
+
   <%# /商品一覧 %>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,10 +28,12 @@
   <% if current_user.id == @item.user.id %>
     <%= link_to "商品の編集", edit_item_path(@item), data: {method: :get, turbo: false}, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%# <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
   <%# 出品者本人以外には購入ボタンを表示する %>
   <% else %>
-    <%= link_to "購入画面に進む", item_purchases_path(@item), data: {turbo: false}, class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%# <%= link_to "購入画面に進む", item_purchases_path(@item), data: {turbo: false}, class:"item-red-btn"%>
   <% end %>
 <% end %>
 
@@ -101,9 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,20 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
-      <% if @item.user == current_user && @item.status == '出品中' %>
-        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item), method: :delete, class: "item-destroy" %>
-      <% elsif @item.user != current_user && @item.status == '出品中' %>
-        <%= link_to "購入画面に進む", new_purchase_path(item_id: @item.id), class: "item-red-btn" %>
-      <% end %>
-    <% end %>
+    <% if @item.purchase == nil && user_signed_in? %>
+  <%# ログインユーザーが出品した商品には編集・削除ボタンが表示される %>
+  <% if current_user.id == @item.user.id %>
+    <%= link_to "商品の編集", edit_item_path(@item), data: {method: :get, turbo: false}, class: "item-red-btn" %>
+    <p class="or-text">or</p>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+  <%# 出品者本人以外には購入ボタンを表示する %>
+  <% else %>
+    <%= link_to "購入画面に進む", item_purchases_path(@item), data: {turbo: false}, class:"item-red-btn"%>
+  <% end %>
+<% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,34 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class: "item-box-img" %>
+      <% if @item.status == '売却済み' %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_fee_burden.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if @item.user == current_user && @item.status == '出品中' %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item), method: :delete, class: "item-destroy" %>
+      <% elsif @item.user != current_user && @item.status == '出品中' %>
+        <%= link_to "購入画面に進む", new_purchase_path(item_id: @item.id), class: "item-red-btn" %>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,37 +40,37 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品の通報</span>
       </div>
     </div>
@@ -89,8 +86,8 @@
         不快な言葉遣いなどは利用制限や退会処分となることがあります。
       </p>
       <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
+        <span>コメントする</span>
       </button>
     </form>
   </div>
@@ -103,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,8 @@
     <% if @item.purchase == nil && user_signed_in? %>
   <%# ログインユーザーが出品した商品には編集・削除ボタンが表示される %>
   <% if current_user.id == @item.user.id %>
-    <%= link_to "商品の編集", edit_item_path(@item), data: {method: :get, turbo: false}, class: "item-red-btn" %>
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%# <%= link_to "商品の編集", edit_item_path(@item), data: {method: :get, turbo: false}, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <%# <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: 'registrations' }
-  resources :items, only: [:index, :new, :create, :show]
+  devise_for :users 
+  # controllers: { registrations: 'registrations' }
+  resources :items, only: [:index, :new, :create, :show, :edit]
+
+  resources :items do
+    resources :purchases
+  end
+
 
   root to: "items#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations' }
-  resources :items, only: [:index, :new, :create]
- 
-  # ユーザーのプロフィール表示
-  get '/users/:id', to: 'users#show', as: :user
+  resources :items, only: [:index, :new, :create, :show]
 
   root to: "items#index"
 end

--- a/db/migrate/20230831030340_create_purchases.rb
+++ b/db/migrate/20230831030340_create_purchases.rb
@@ -1,0 +1,10 @@
+class CreatePurchases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :purchases do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_093540) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_31_030340) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -62,6 +62,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_093540) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchases", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -89,4 +98,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_093540) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end


### PR DESCRIPTION
# what
商品詳細機能を実装

 # why
商品の詳細画面を確認できるようにするため


 ## ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/17636a16b9ea01fdcebf86f912189ad7

 ## ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7d83b5ac06ebb881832187a87460384b

 ## ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
承認購入機能は未実装

 ## ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/f3a8773554219dbbc5177f45552ddbe9


商品購入用のテーブルとDBだけ作成してあります。
なので、商品購入機能は未実装ですが一部ページの表示だけできるようにしました。